### PR TITLE
Made it MinGW compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ libpkgconf/config.h:
 psp-pkg-config: libpkgconf/config.h ${OBJS}
 	@echo "CCLD $@"
 	@${CC} ${STATIC} -o $@ ${OBJS}
-	@${STRIP} $@
+	@${STRIP} $@ | @${STRIP}.exe $@ 
 
 install: psp-pkg-config
 	mkdir -p ${DESTDIR}${PSPDEV}/bin

--- a/libpkgconf/libpkgconf-api.h
+++ b/libpkgconf/libpkgconf-api.h
@@ -5,6 +5,7 @@
  * Unfortunately, that is not available when building with cmake, so use attributes instead,
  * in a way that doesn't depend on any cmake magic.
  */
+#define DLL_EXPORT
 #if defined(PKGCONFIG_IS_STATIC)
 # define PKGCONF_API
 #elif defined(_WIN32) || defined(_WIN64)


### PR DESCRIPTION
Dunno why but `strip` requires exe extension.
Also functions were being marked as imported causing linking issues.